### PR TITLE
Allow for installation via npm directly from github URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 [`weekly.js`](weekly.js) is a script that helps my weekly GTD review.
 
 [![asciicast](https://asciinema.org/a/joY4R0pPLKVGxlhdMwgbVAHqc.png)](https://asciinema.org/a/joY4R0pPLKVGxlhdMwgbVAHqc)
+
+# Installation
+
+    npm install -g {github repo url}
+
+Prefix with sudo if necessary.
+
+# Running
+
+    > weekly.js
+
+# Prerequisites
+
+You need taskwarrior and taskserver installed.

--- a/package.json
+++ b/package.json
@@ -1,9 +1,14 @@
 {
+  "name": "weekly.js",
+  "version": "0.1.0",
   "dependencies": {
     "boxen": "^1.3.0",
     "chalk": "^2.4.1",
     "inquirer": "^6.0.0",
     "moment": "^2.22.2",
     "standard": "^11.0.1"
+  },
+  "bin": {
+    "weekly.js" : "./weekly.js"
   }
 }


### PR DESCRIPTION
Hey abesto. I like your script.

I did however find it cumbersome to download and install manually, so I thought that maybe I'd just extend the package.json so that in the future it was possible to install your script directly from GH URL.